### PR TITLE
Improve responsiveness of organization hierarchy component

### DIFF
--- a/src/shared/components/organization-hierarchy/index.tsx
+++ b/src/shared/components/organization-hierarchy/index.tsx
@@ -46,7 +46,7 @@ export default function UnitHierarchy({
     setIsDisableModalOpen,
   } = useUnitHierarchy({ organizations, originalData, pagination, users })
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 h-[700px]">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
       <div className="flex flex-col border rounded-lg">
         <div className="p-4 border-b">
           <div className="space-y-3">


### PR DESCRIPTION
<details>
  <summary><h2>PR Checklist</h2></summary>

- [ ] I ran the code that changed and verified that everything is working as
      expected.
- [ ] I checked the CI/CD workflows and everything is passing without errors.
- [ ] This PR is up to date with the base branch and ready to be merged.
- [ ] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [ ] I added a meaningful description for this PR.
- [ ] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR.
- [ ] I updated the README to reflect the new changes that affect the
      information in there.
- [ ] I updated all the existing unit tests to cover the changes in this PR.
- [ ] I added all the relevant screenshots (only needed for PRs that change the
      UI).
- [ ] I added the links with relevant information needed to review the PR.
- [ ] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes


Remove fixed height from the organization hierarchy component to enhance responsiveness across different screen sizes.
<!-- Add here a meaningful description for this PR -->

## PR requirements (migrations, environment variables, external configs, etc.)

<!-- Add here all the requirements of this PR. Migrations, templates configuration, etc. -->

## Screenshots

<!-- If this PR includes changes to the UI, add here screenshots that reflect the changes -->
Before
<img width="3436" height="2194" alt="image" src="https://github.com/user-attachments/assets/898b4661-884d-4d37-be4d-ffd71455fffb" />


After
<img width="3514" height="2279" alt="image" src="https://github.com/user-attachments/assets/b6efdf89-eb1f-4714-ad00-2ebfd5651cbb" />


## Related links

<!-- Links to test files, documentation, etc. -->