### PR TITLE
fix: include null values in disabled organization filter

### DIFF
--- a/src/features/units/plugins/queries/unit.queries.ts
+++ b/src/features/units/plugins/queries/unit.queries.ts
@@ -18,7 +18,18 @@ export const getAllUnits = async () => {
         path: true,
       },
       where: {
-        disabled: { equals: false },
+        or: [
+          {
+            disabled: {
+              equals: false,
+            },
+          },
+          {
+            disabled: {
+              equals: null,
+            },
+          },
+        ],
       },
       limit: 0,
       overrideAccess: false,
@@ -42,6 +53,10 @@ export const getUnitsWithFilter = async ({ status, type }: { status?: string; ty
   const { payload } = await getPayloadContext()
   const { user } = await getAuthUser()
 
+  const disabledFilter = {
+    or: [{ disabled: { equals: false } }, { disabled: { equals: null } }],
+  }
+
   if (!user) {
     return {
       docs: [],
@@ -64,7 +79,7 @@ export const getUnitsWithFilter = async ({ status, type }: { status?: string; ty
       limit: 0,
       sort: ['createdAt'],
       where: {
-        disabled: { equals: null },
+        ...disabledFilter,
         ...(status ? { status: { equals: status } } : {}),
         ...(type ? { type: { equals: type } } : {}),
       },
@@ -108,7 +123,7 @@ export const getUnitsWithFilter = async ({ status, type }: { status?: string; ty
         },
       },
       {
-        disabled: { equals: false },
+        ...disabledFilter,
       },
       ...(status ? [{ status: { equals: status } }] : []),
       ...(type ? [{ type: { equals: type } }] : []),


### PR DESCRIPTION
<details>
  <summary><h2>PR Checklist</h2></summary>

- [x] I ran the code that changed and verified that everything is working as
      expected.
- [x] I checked the CI/CD workflows and everything is passing without errors.
- [x] This PR is up to date with the base branch and ready to be merged.
- [x] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [x] I added a meaningful description for this PR.
- [x] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR.
- [x] I updated the README to reflect the new changes that affect the
      information in there.
- [x] I updated all the existing unit tests to cover the changes in this PR.
- [x] I added all the relevant screenshots (only needed for PRs that change the
      UI).
- [x] I added the links with relevant information needed to review the PR.
- [x] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes
Include null values in disabled organization filter
<!-- Add here a meaningful description for this PR -->

## PR requirements (migrations, environment variables, external configs, etc.)
none
<!-- Add here all the requirements of this PR. Migrations, templates configuration, etc. -->

## Screenshots
none
<!-- If this PR includes changes to the UI, add here screenshots that reflect the changes -->

## Related links
none
<!-- Links to test files, documentation, etc. -->
