### PR TITLE
feat: add login accessibility

### DIFF
--- a/.plans/giq-50.md
+++ b/.plans/giq-50.md
@@ -1,0 +1,95 @@
+---
+status: pending-review
+ticket: GIQ-50
+sprint: TBD
+standard: WCAG 2.1 Level AA
+implementation_commit: d0ef4607de9a29377b4f6894f1f5beb98530fa14
+linear_url: https://linear.app/meltstudio/issue/GIQ-50
+---
+
+# GIQ-50 — ACC-01 Landing & Login: form and dialog accessibility
+
+## Requirements summary
+
+From [Linear GIQ-50](https://linear.app/meltstudio/issue/GIQ-50):
+
+- **Objective:** Users signing in with assistive technology (and password managers) get correct field semantics, modal behavior, and recoverable error messaging on the landing/login-related routes.
+- **Scope (routes):** `/login`, `/forgot-password`, `/reset-password`, `/login/create-first-user`.
+- **Design intent:**
+  - Appropriate HTML `autocomplete` on email/password fields (`email`, `current-password`, `new-password` where applicable).
+  - Dialog roots used in the flow expose `aria-modal="true"`; focus trap should stay consistent with Radix behavior.
+  - Invalid-credentials feedback must not be a silent/generic toast; it should include resolution guidance (e.g. link to forgot password) without revealing whether email or password failed.
+- **Acceptance (functional):** Screen reader users hear labels + autocomplete roles; password managers can offer credentials; dialogs announce as modals with focus trapped; failed login errors are announced and include recovery guidance.
+- **Verification (from ticket):** Manual SR pass (NVDA / VoiceOver), password manager check (e.g. 1Password), automated axe pass with zero **critical** issues on the login surface.
+
+**Accessibility standard for this round:** All new or changed behaviors should be judged against **WCAG 2.1 Level AA** (including related understanding for name/role/value, labels, status messages, and focus order).
+
+## PRD alignment
+
+Implements **Component A — Landing & Login** from PRD `features/accessibility/prd.md` (referenced in Linear). Fits the broader accessibility uplift (PoC → Prototype).
+
+## Implementation status (mapped to `d0ef4607`)
+
+| Requirement                                    | Status                        | Notes                                                                                                                                  |
+| ---------------------------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `autocomplete` on login email/password         | Done                          | `login-form.tsx`: `email`, `current-password`                                                                                          |
+| `autocomplete` on forgot-password email        | Done                          | `forgot-password-form.tsx`: `email`                                                                                                    |
+| `autocomplete` on reset password fields        | Done                          | `reset-password-form.tsx`: `new-password` on both fields                                                                               |
+| `autocomplete` on create-first-user            | Done                          | `useCreateFirstUserForm.ts` + `FieldData.autoComplete` wired through `text.tsx` / `password.tsx`                                       |
+| `aria-modal="true"` on dialogs                 | Done                          | `dialog.tsx` → `DialogPrimitive.Content` (applies to all consumers of shared `Dialog`)                                                 |
+| Clear invalid-credentials copy + recovery link | Done                          | `useLogin.tsx` → `toast.custom` with heading, explanatory text, link to `/forgot-password` (matches “don’t reveal which field failed”) |
+| Locked-account path                            | Unchanged from prior behavior | Still uses `toast.custom` with copy + link — re-validate with SR                                                                       |
+
+**Files touched in commit:** `login-form.tsx`, `forgot-password-form.tsx`, `reset-password-form.tsx`, `useLogin.tsx`, `useCreateFirstUserForm.ts`, `form-hook-helper/fields/text.tsx`, `form-hook-helper/fields/password.tsx`, `form-hook-helper/types.ts`, `dialog.tsx`.
+
+## Files to modify/create (for follow-up, if validation finds gaps)
+
+- `src/features/auth/hooks/useLogin.tsx` — only if toast semantics need `role="alert"` / `aria-live` refinement for WCAG 4.1.3 (Status Messages) after testing.
+- `src/shared/components/ui/sonner.tsx` — only if global Toaster region needs explicit `toastOptions` or props for announcements (confirm against Sonner + SR behavior first).
+
+## Implementation steps (completed in branch / commit above)
+
+1. Add `autoComplete` to controlled login and auth-related forms (login, forgot, reset, first-user field config).
+2. Extend `FieldData` with optional `autoComplete` and pass through shared form helpers.
+3. Set `aria-modal="true"` on shared dialog content (Radix Dialog).
+4. Replace generic invalid-credentials toast with rich custom content including recovery link.
+
+## Validation plan (run after your review, before merge)
+
+**Automated**
+
+1. `pnpm ci:checks` (lint + typecheck) on the branch containing `d0ef4607`.
+2. **axe** (browser extension or CI if configured): open `/login`, `/forgot-password`, `/reset-password`, `/login/create-first-user`; confirm **no critical** violations on those pages (per ticket). For AA, also note serious issues and fix or ticket separately.
+
+**Manual — WCAG 2.1 AA lens**
+
+3. **Keyboard & focus (2.1.1, 2.4.3, 2.4.7):** Tab through each form; focus order logical; focus visible; dialog open/close returns focus appropriately.
+4. **Labels & names (1.3.1, 4.1.2):** Each control has associated label; email/password fields expose correct accessible name and `autocomplete` in devtools/inspector.
+5. **Password managers:** With 1Password (or equivalent), confirm save/fill prompts align with `autocomplete` on `/login` and related routes.
+6. **Screen readers:** VoiceOver (macOS) and/or NVDA (Windows): tab into fields — hear label + field type; submit invalid credentials — hear error **content** (not silent); open any dialog in login flow — hear modal behavior; confirm focus trapped until dismiss (Radix default).
+7. **Status messages (4.1.3 AA):** After failed login, verify the toast region is exposed as a live region (Sonner typically does; confirm with SR “read all” / announcements). If announcements are unreliable, add explicit live region / `role="alert"` on the custom toast wrapper in a follow-up commit.
+8. **Non-text contrast (1.4.3):** Check error toast text/link contrast against background (red palette) meets 4.5:1 for normal text.
+
+**UX audit (optional but recommended for UI work)**
+
+9. Run `/melt-ux-audit` for loading/empty/error states and navigation on the affected routes.
+
+## Edge cases and risks
+
+- **Global `Dialog` change:** `aria-modal="true"` on shared `DialogContent` affects every dialog in the app — generally correct for Radix Dialog; regression-test a few non-auth dialogs for SR + focus.
+- **Toast vs SR:** Custom `toast.custom` JSX may need explicit ARIA if Sonner’s wrapper doesn’t announce reliably in your target browsers.
+- **Both password fields `new-password` on reset:** Matches HTML guidance for “choose new password” flows; confirm password managers still behave as expected.
+
+## Non-code changes
+
+- None required for this story (no new env vars or migrations).
+
+## Open questions
+
+1. **Sprint folder:** This file lives at `.plans/giq-50.md` (slug from issue id). If the team standardizes on `.plans/<sprint>/GIQ-50.md`, move/rename when sprint id is confirmed.
+2. **axe scope:** Ticket says “login surface” — confirm whether that means **only** `/login` for the zero-critical bar or all four routes equally.
+3. **Post-review:** After you approve, commit with `docs(plan): add plan for GIQ-50` (or merge with feature commit as appropriate), then open PR from suggested branch `feature/giq-50-acc-01-landing-login-form-and-dialog-accessibility` (from Linear).
+
+## Changes log
+
+- _2026-05-04:_ Initial plan written; implementation referenced to `d0ef4607`; validation and WCAG 2.1 AA criteria captured. Not committed per developer request.

--- a/src/features/auth/forms/forgot-password-form.tsx
+++ b/src/features/auth/forms/forgot-password-form.tsx
@@ -64,6 +64,7 @@ export function ForgotPasswordForm() {
                   <Input
                     id="email"
                     type="email"
+                    autoComplete="email"
                     placeholder="Enter your email address"
                     disabled={isLoading}
                     className="pl-10"

--- a/src/features/auth/forms/login-form.tsx
+++ b/src/features/auth/forms/login-form.tsx
@@ -31,6 +31,7 @@ export function LoginForm() {
                   id="email"
                   name="email"
                   type="email"
+                  autoComplete="email"
                   required
                   value={loginFields.email}
                   onChange={handleInputChange}
@@ -49,6 +50,7 @@ export function LoginForm() {
                 <PasswordInput
                   id="password"
                   name="password"
+                  autoComplete="current-password"
                   required
                   value={loginFields.password}
                   onChange={handleInputChange}

--- a/src/features/auth/forms/reset-password-form.tsx
+++ b/src/features/auth/forms/reset-password-form.tsx
@@ -56,6 +56,7 @@ export function ResetPasswordForm() {
                 <LockIcon className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
                 <PasswordInput
                   id="password"
+                  autoComplete="new-password"
                   placeholder="Enter your new password"
                   {...register('password')}
                   className={`pl-10 ${errors.password ? 'border-red-500' : ''}`}
@@ -71,6 +72,7 @@ export function ResetPasswordForm() {
                 <LockIcon className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
                 <PasswordInput
                   id="confirmPassword"
+                  autoComplete="new-password"
                   placeholder="Confirm your new password"
                   {...register('confirmPassword')}
                   className={`pl-10 ${errors.confirmPassword ? 'border-red-500' : ''}`}

--- a/src/features/auth/hooks/useLogin.tsx
+++ b/src/features/auth/hooks/useLogin.tsx
@@ -62,7 +62,26 @@ export function useLogin() {
 
       window.location.href = '/dashboard'
     } catch {
-      toast.error('Invalid credentials')
+      toast.custom((t) => (
+        <div
+          role="alert"
+          className="p-4 bg-red-100 rounded-md shadow text-sm border border-red-200"
+        >
+          <p className="font-semibold text-red-800">Sign-in failed</p>
+          <p className="mt-2 text-red-700">
+            We couldn&apos;t sign you in with those credentials. If you&apos;ve forgotten your
+            password, you can{' '}
+            <Link
+              href="/forgot-password"
+              className="text-red-900 underline font-medium"
+              onClick={() => toast.dismiss(t)}
+            >
+              reset it here
+            </Link>
+            .
+          </p>
+        </div>
+      ))
     }
   }
 

--- a/src/features/users/hooks/useCreateFirstUserForm.ts
+++ b/src/features/users/hooks/useCreateFirstUserForm.ts
@@ -22,11 +22,13 @@ export function useCreateFirstUserForm() {
           label: 'Email *',
           name: 'email',
           type: 'text',
+          autoComplete: 'email',
         },
         {
           label: 'Password *',
           name: 'password',
           type: 'password',
+          autoComplete: 'new-password',
         },
       ],
       onSubmit: async (submitData) => {

--- a/src/shared/components/form-hook-helper/fields/password.tsx
+++ b/src/shared/components/form-hook-helper/fields/password.tsx
@@ -32,7 +32,11 @@ export const PasswordInputHelper = <TFieldValues extends FieldValues>({
             required={isRequired}
           />
           <FormControl>
-            <PasswordInput {...field} placeholder={fieldData.placeholder} />
+            <PasswordInput
+              {...field}
+              autoComplete={fieldData.autoComplete}
+              placeholder={fieldData.placeholder}
+            />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/shared/components/form-hook-helper/fields/text.tsx
+++ b/src/shared/components/form-hook-helper/fields/text.tsx
@@ -33,7 +33,12 @@ export const TextInputHelper = <TFieldValues extends FieldValues>({
             required={isRequired}
           />
           <FormControl>
-            <Input type={fieldData.type} {...field} placeholder={fieldData.placeholder} />
+            <Input
+              type={fieldData.type}
+              {...field}
+              autoComplete={fieldData.autoComplete}
+              placeholder={fieldData.placeholder}
+            />
           </FormControl>
           <FormMessage />
         </FormItem>

--- a/src/shared/components/form-hook-helper/types.ts
+++ b/src/shared/components/form-hook-helper/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { HTMLInputAutoCompleteAttribute, ReactNode } from 'react'
 import type { FieldValues, Path } from 'react-hook-form'
 import { DatePickerProps } from 'react-datepicker'
 import { Tree } from '@/features/units'
@@ -70,4 +70,5 @@ export type FieldData<TFieldValues extends FieldValues = FieldValues> = {
   disabled?: boolean
   required?: boolean
   hidden?: boolean
+  autoComplete?: HTMLInputAutoCompleteAttribute
 }

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -48,6 +48,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        aria-modal="true"
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
           className,


### PR DESCRIPTION
<details>
  <summary><h2>PR Checklist</h2></summary>

- [ ] I ran the code that changed and verified that everything is working as
      expected.
- [ ] I checked the CI/CD workflows and everything is passing without errors.
- [ ] This PR is up to date with the base branch and ready to be merged.
- [ ] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [ ] I added a meaningful description for this PR.
- [ ] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR.
- [ ] I updated the README to reflect the new changes that affect the
      information in there.
- [ ] I updated all the existing unit tests to cover the changes in this PR.
- [ ] I added all the relevant screenshots (only needed for PRs that change the
      UI).
- [ ] I added the links with relevant information needed to review the PR.
- [ ] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes

Improves accessibility and UX around authentication: `autocomplete` hints for browsers and password managers, a clearer failed sign-in message with a path to forgot password, and `aria-modal` on dialog content for assistive technologies.
## Changes
### `autoComplete` on auth forms
- **Login:** `email` and `current-password` on email and password fields.
- **Forgot password:** `email` on the email input.
- **Reset password:** `new-password` on both password fields.
### Form hook helper
- Extended `FieldData` with optional `autoComplete`.
- **Text** and **password** field helpers pass `autoComplete` through to `Input` / `PasswordInput`.
- **Create first user** flow sets `email` and `new-password` for those fields.
### Login error handling (`useLogin.tsx`)
- Replaces a generic “Invalid credentials” toast with a custom toast that explains the failure, includes a link to `/forgot-password`, and dismisses the toast when the link is clicked.
### Dialog
- Adds `aria-modal="true"` on `DialogPrimitive.Content` so modals are exposed correctly to screen readers.



<!-- Add here a meaningful description for this PR -->

## PR requirements (migrations, environment variables, external configs, etc.)

<!-- Add here all the requirements of this PR. Migrations, templates configuration, etc. -->

## Screenshots

<!-- If this PR includes changes to the UI, add here screenshots that reflect the changes -->
<img width="1470" height="956" alt="Screenshot 2026-05-04 at 10 54 53 AM" src="https://github.com/user-attachments/assets/40cb8fdb-7a02-40cb-a13e-1ea21644d37e" />

## Related links

<!-- Links to test files, documentation, etc. -->

[GIQ-50](https://linear.app/meltstudio/issue/GIQ-50)