### PR TITLE
fix(web): GIQ-59 data table pagination and search SR names

### DIFF
--- a/.plans/giq-59.md
+++ b/.plans/giq-59.md
@@ -1,0 +1,90 @@
+---
+status: implemented
+ticket: GIQ-59
+sprint: TBD
+standard: WCAG 2.1 Level AA
+linear_url: https://linear.app/meltstudio/issue/GIQ-59
+---
+
+# GIQ-59 — ACC-10 Data tables: pagination and comboboxes
+
+Source of truth: [Linear GIQ-59](https://linear.app/meltstudio/issue/GIQ-59).
+
+## Requirements Summary
+
+- **Feature:** accessibility · **Priority:** P2 · **Category:** Bug
+- **Conformance target:** WCAG 2.1 Level AA for this round of updates.
+- **Scope:** paginated tables — manual QA on **Users** and **Tenants** routes, with reusable fixes in shared **DataTable** primitives.
+- **Acceptance:** pagination controls expose meaningful names/state, **Rows per page** combobox announces its selected value, table **search** inputs have meaningful accessible names where that filter is used.
+- **Team rules:** decorative icons beside visible text or control labels use `aria-hidden="true"`; do not add `role="alert"` or assertive live regions for this work. See also [GIQ-53](giq-53.md) for live-region policy.
+
+## PRD Alignment
+
+- Aligns with `features/accessibility/prd.md`, Component E — Data Tables.
+- Builds on **GIQ-58** (table semantics and row actions); this story focuses on **pagination**, **rows-per-page** exposure, and **search** labeling.
+
+## Open PR / Conflict Review
+
+- Open PR [#133](https://github.com/Nesvig-Trani/StyreIQ/pull/133) (GIQ-58) overlaps `DataTable` + Users/Tenants table files. **GIQ-59** implementation targets shared `pagination.tsx`, `filters/search.tsx`, `toolbar.tsx`, `types.ts`, and optionally `ui/select.tsx` to reduce merge churn. **Rebase onto `dev` after #133 merges** if both land.
+
+## Files To Modify / Create
+
+| Path                                                                                                            | Purpose                                                                                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`src/shared/components/data-table/pagination.tsx`](../src/shared/components/data-table/pagination.tsx)         | Destination-aware `aria-label`s on pagination buttons; rows-per-page trigger name includes selected value; zero-page edge cases; `SelectValue` without incorrect placeholder use. |
+| [`src/shared/components/data-table/filters/search.tsx`](../src/shared/components/data-table/filters/search.tsx) | `aria-label` from `label` or `placeholder`; `"use client"`.                                                                                                                       |
+| [`src/shared/components/data-table/types.ts`](../src/shared/components/data-table/types.ts)                     | Optional `label` on `DataTableSearchFilter`.                                                                                                                                      |
+| [`src/shared/components/data-table/toolbar.tsx`](../src/shared/components/data-table/toolbar.tsx)               | Pass `label` to search filter; `CrossIcon` on Reset `aria-hidden`.                                                                                                                |
+| [`src/shared/components/ui/select.tsx`](../src/shared/components/ui/select.tsx)                                 | Chevron on trigger `aria-hidden="true"` (decorative).                                                                                                                             |
+
+Feature tables ([`user-table`](../src/features/users/components/user-table/index.tsx), [`tenants-table`](../src/features/tenants/components/tenants-table.tsx]): avoid unless needed for copy or after GIQ-58 rebase.
+
+## Implementation Steps
+
+1. Rebase or update after PR **#133** lands, or keep GIQ-59 scoped to shared files until then.
+2. **`DataTablePagination`:** derive `pageCount`, `currentPage`, handle **zero pages** (“No pages”, safe button labels).
+3. **Pagination `aria-label`s:** destination-aware first / previous / next / last; when disabled at ends, clarify “already on first/last page”.
+4. **Rows per page:** `SelectTrigger` `aria-label` including current value (e.g. `Rows per page, 10 rows selected`); `<SelectValue />` without numeric `placeholder` misuse.
+5. **Decorative icons:** pagination Lucide icons, select chevron, reset icon — `aria-hidden` where redundant with text/`aria-label`.
+6. **`DataTableSearchFilter`:** default `aria-label` from `placeholder`; allow explicit `label` in filter defs.
+7. Run **`pnpm ci:checks`** before merge.
+
+## Validation Plan
+
+- **Static:** `pnpm lint`, `pnpm type-check`, `pnpm ci:checks`.
+- **Manual — `/dashboard/users`:** rows-per-page combobox and pagination buttons announce action + page context; tenant filter if “all tenants” view.
+- **Manual — `/dashboard/tenants`:** same for pagination and rows-per-page.
+- **Search:** validate on any route that registers a **`type: 'search'`** global filter; Users/Tenants may not expose search today — document the route used for QA.
+- **Automated:** axe / Lighthouse on Users and Tenants — no critical issues in pagination/combobox/search areas.
+- **UX:** optional `/melt-ux-audit` for loading/empty/error and URL state.
+
+## Edge Cases And Risks
+
+- **#133** overlap — rebase when GIQ-58 merges.
+- Radix **Select** empty value span — mitigated by trigger `aria-label` + correct `SelectValue` usage.
+- **`pageCount === 0`** — avoid `page 1 of 0`; use “No pages” and disabled-safe button copy.
+
+## Non-Code Changes
+
+- No migrations, env vars, or new dependencies.
+
+## Summary (implementation)
+
+- **`pagination.tsx`:** Destination-aware labels; removed duplicate sr-only spans in favor of `aria-label`; rows-per-page `aria-label` includes selected **`pageSize`**; visible page indicator shows “No pages” when `pageCount === 0`.
+- **`search.tsx` / `types.ts` / `toolbar.tsx`:** Optional **`label`** on search filter type; **`aria-label`** defaults from placeholder; Reset icon **`aria-hidden`**.
+- **`select.tsx`:** Trigger chevron **`aria-hidden="true"`**.
+
+Coordinate with **GIQ-58** / PR **#133** before merging if both touch the same feature branches.
+
+## Validation Results (Agent)
+
+- **`pnpm ci:checks`** (ESLint + `tsc --noEmit`) — pass (2026-05-06).
+- **No unit test script** in this repo; manual screen-reader QA on Users/Tenants routes is still recommended before merge.
+
+## Validation Results (Developer)
+
+- Pending — please complete manual QA per **Validation Plan** (`/dashboard/users`, `/dashboard/tenants`, optional axe/Lighthouse) and record outcome here before merge.
+
+## Review Results (Developer)
+
+- Pending — human code review required per team policy before merge.

--- a/src/shared/components/data-table/filters/search.tsx
+++ b/src/shared/components/data-table/filters/search.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { Table } from '@tanstack/react-table'
 import type { ChangeEventHandler } from 'react'
 import { useEffect, useState } from 'react'
@@ -13,13 +15,16 @@ const searchSchema = z.string().nonempty().catch('')
 type DataTableSearchFilterProps<TData> = {
   table: Table<TData>
   id: string
+  label?: string
   placeholder?: string
 }
 
 export const DataTableSearchFilter = <TData,>(
   props: DataTableSearchFilterProps<TData>,
 ): React.ReactNode => {
-  const { table, id, placeholder = 'Search' } = props
+  const { table, id, label, placeholder = 'Search' } = props
+
+  const ariaLabel = label || placeholder || 'Search'
 
   const globalFilter = globalFilterSchema.parse(table.getState().globalFilter)
   const valueFromGlobalFilter = searchSchema.parse(globalFilter[id])
@@ -43,6 +48,7 @@ export const DataTableSearchFilter = <TData,>(
 
   return (
     <Input
+      aria-label={ariaLabel}
       placeholder={placeholder}
       value={value}
       onChange={handleChange}

--- a/src/shared/components/data-table/pagination.tsx
+++ b/src/shared/components/data-table/pagination.tsx
@@ -16,7 +16,6 @@ import {
   ChevronsLeftIcon,
   ChevronsRightIcon,
 } from 'lucide-react'
-import { useId } from 'react'
 
 const DEFAULT_PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50]
 
@@ -28,18 +27,35 @@ type DataTablePaginationProps<TData> = {
 export const DataTablePagination = <TData,>(
   props: DataTablePaginationProps<TData>,
 ): React.ReactNode => {
-  const id = useId()
-  const labelId = `rows-per-page-${id}`
-
   const { table, pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS } = props
 
   const tableState = table.getState()
   const { pageSize, pageIndex } = tableState.pagination
   const isSomeRowsSelected = table.getIsSomeRowsSelected()
 
+  const pageCount = table.getPageCount()
+  const currentPage = pageCount === 0 ? 0 : pageIndex + 1
+  const safePageCount = Math.max(0, pageCount)
+
+  const canPrevious = table.getCanPreviousPage()
+  const canNext = table.getCanNextPage()
+
+  const rowsPerPageLabel = `Rows per page, ${pageSize} rows selected`
+
   const handlePageSizeChange = (value: string): void => {
     table.setPageSize(parseInt(value, 10))
   }
+
+  const buildPageNavLabel = (action: string, targetPage: number, isActive: boolean): string => {
+    if (safePageCount === 0) return `${action}, no pages`
+    if (isActive) return `Go to ${action}, page ${targetPage} of ${safePageCount}`
+    return `Go to ${action} (already on page ${currentPage} of ${safePageCount})`
+  }
+
+  const firstPageLabel = buildPageNavLabel('first page', 1, pageIndex > 0)
+  const previousPageLabel = buildPageNavLabel('previous page', pageIndex, canPrevious)
+  const nextPageLabel = buildPageNavLabel('next page', pageIndex + 2, canNext)
+  const lastPageLabel = buildPageNavLabel('last page', safePageCount, pageIndex < safePageCount - 1)
 
   return (
     <div
@@ -57,12 +73,10 @@ export const DataTablePagination = <TData,>(
 
       <div className="flex flex-col items-end space-y-2 md:flex-row md:space-x-6 md:space-y-0 lg:space-x-4">
         <div className="flex items-center gap-4">
-          <p className="text-sm font-medium !my-0" id={labelId}>
-            Rows per page
-          </p>
+          <p className="text-sm font-medium my-0!">Rows per page</p>
           <Select value={pageSize.toString()} onValueChange={handlePageSizeChange}>
-            <SelectTrigger className="h-8 w-[80px]" aria-labelledby={labelId}>
-              <SelectValue placeholder={pageSize} />
+            <SelectTrigger className="h-8 w-[80px]" aria-label={rowsPerPageLabel}>
+              <SelectValue />
             </SelectTrigger>
             <SelectContent side="top">
               {pageSizeOptions.map((option) => (
@@ -76,7 +90,13 @@ export const DataTablePagination = <TData,>(
 
         <div className="flex flex-row items-center">
           <div className="flex w-[100px] items-center justify-center text-sm font-medium">
-            Page {pageIndex + 1} of {table.getPageCount()}
+            {safePageCount === 0 ? (
+              <span>No pages</span>
+            ) : (
+              <span>
+                Page {currentPage} of {safePageCount}
+              </span>
+            )}
           </div>
 
           <div className="flex items-center space-x-2">
@@ -86,9 +106,8 @@ export const DataTablePagination = <TData,>(
               onClick={(): void => table.setPageIndex(0)}
               disabled={!table.getCanPreviousPage()}
               aria-disabled={!table.getCanPreviousPage()}
-              aria-label="Go to first page"
+              aria-label={firstPageLabel}
             >
-              <span className="sr-only">Go to first page</span>
               <ChevronsLeftIcon className="h-4 w-4" aria-hidden="true" />
             </Button>
 
@@ -98,9 +117,8 @@ export const DataTablePagination = <TData,>(
               onClick={(): void => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
               aria-disabled={!table.getCanPreviousPage()}
-              aria-label="Go to previous page"
+              aria-label={previousPageLabel}
             >
-              <span className="sr-only">Go to previous page</span>
               <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
             </Button>
 
@@ -110,9 +128,8 @@ export const DataTablePagination = <TData,>(
               onClick={(): void => table.nextPage()}
               disabled={!table.getCanNextPage()}
               aria-disabled={!table.getCanNextPage()}
-              aria-label="Go to next page"
+              aria-label={nextPageLabel}
             >
-              <span className="sr-only">Go to next page</span>
               <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
             </Button>
 
@@ -122,9 +139,8 @@ export const DataTablePagination = <TData,>(
               onClick={(): void => table.setPageIndex(table.getPageCount() - 1)}
               disabled={!table.getCanNextPage()}
               aria-disabled={!table.getCanNextPage()}
-              aria-label="Go to last page"
+              aria-label={lastPageLabel}
             >
-              <span className="sr-only">Go to last page</span>
               <ChevronsRightIcon className="h-4 w-4" aria-hidden="true" />
             </Button>
           </div>

--- a/src/shared/components/data-table/toolbar.tsx
+++ b/src/shared/components/data-table/toolbar.tsx
@@ -61,6 +61,7 @@ export const DataTableToolbar = <TData,>(props: DataTableToolbarProps<TData>): R
                   key={filter.id}
                   table={table}
                   id={filter.id}
+                  label={filter.label}
                   placeholder={filter.placeholder}
                 />
               )
@@ -147,7 +148,7 @@ export const DataTableToolbar = <TData,>(props: DataTableToolbarProps<TData>): R
               className="h-8 px-2 lg:px-3 w-full sm:w-auto"
             >
               Reset
-              <CrossIcon className="ml-2 h-4 w-4" />
+              <CrossIcon className="ml-2 h-4 w-4" aria-hidden="true" />
             </Button>
           )}
         </div>

--- a/src/shared/components/data-table/types.ts
+++ b/src/shared/components/data-table/types.ts
@@ -6,6 +6,8 @@ export type DataTableSorting<TData> = {
 export type DataTableSearchFilter = {
   type: 'search'
   id: string
+  /** Accessible name when there is no visible `<label>` (preferred over placeholder for SR). */
+  label?: string
   placeholder?: string
 }
 

--- a/src/shared/components/ui/select.tsx
+++ b/src/shared/components/ui/select.tsx
@@ -38,7 +38,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <ChevronDownIcon className="size-4 opacity-50" aria-hidden="true" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )


### PR DESCRIPTION
<details>
  <summary><h2>PR Checklist</h2></summary>

- [x] I ran the code that changed and verified that everything is working as
      expected (local `pnpm ci:checks`, `pnpm build`).
- [x] I checked the CI/CD workflows and everything is passing without errors
      (pre-commit hooks ran on commit).
- [ ] This PR is up to date with the base branch and ready to be merged.
- [x] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [x] I added a meaningful description for this PR.
- [x] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR (none apply).
- [ ] I updated the README to reflect the new changes that affect the
      information in there (not applicable).
- [ ] I updated all the existing unit tests to cover the changes in this PR
      (repo has no `test` script per AGENTS.md).
- [ ] I added all the relevant screenshots (only needed for PRs that change the
      UI); a11y semantics only — manual SR QA recommended instead.
- [x] I added the links with relevant information needed to review the PR.
- [x] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes

Implements [GIQ-59 — ACC-10 Data tables: pagination and comboboxes](https://linear.app/meltstudio/issue/GIQ-59) (WCAG 2.1 AA scope for this round). Aligns with `features/accessibility/prd.md` **Component E — Data Tables**.

Summary:

- **`DataTablePagination`:** destination-aware `aria-label`s for first/prev/next/last (incl. first/last page and zero-page edge cases); rows-per-page **`SelectTrigger`** `aria-label` includes the selected page size; visible “No pages” when `pageCount === 0`; removed redundant `sr-only` duplicates where `aria-label` names the control.
- **`DataTableSearchFilter`:** `aria-label` from optional **`label`** or **`placeholder`**; **`"use client"`** directive.
- **`types` / `toolbar`:** optional **`label`** on `DataTableSearchFilter`; Reset button **`CrossIcon`** `aria-hidden="true"`.
- **`Select`:** chevron on trigger **`aria-hidden="true"`** (decorative).
- **Plan:** [`.plans/giq-59.md`](.plans/giq-59.md).

**PRD note:** Focuses pagination, rows-per-page value exposure, and table search naming; **GIQ-58** covers table `aria-label` / row actions — coordinate with open [PR #133](https://github.com/Nesvig-Trani/StyreIQ/pull/133) if both land close together (rebase after merge if needed).

## PR requirements (migrations, environment variables, external configs, etc.)

None.

## Screenshots

Not applicable (non-visual a11y). Please run VoiceOver/NVDA on `/dashboard/users` and `/dashboard/tenants` for rows-per-page and pagination (per `.plans/giq-59.md`).

## Related links

- Linear: https://linear.app/meltstudio/issue/GIQ-59
- Plan: `.plans/giq-59.md`
- Overlap note: https://github.com/Nesvig-Trani/StyreIQ/pull/133 (GIQ-58)

**Pre-flight (local):** `pnpm ci:checks`, `pnpm build` — pass.

**Reminder:** Agent-produced code requires **human review** before merge (AGENTS.md).
