### PR TITLE
feat(web): improve accessibility for user details and social toggles

### DIFF
--- a/.cursor/commands/melt-audit.md
+++ b/.cursor/commands/melt-audit.md
@@ -31,10 +31,26 @@ Before running checks, determine the project stack so you can skip inapplicable 
 
 For each applicable category, run the checks below. Mark each item:
 
-- ✅ **Pass** — requirement met (include evidence: file path, config value, or command output)
-- ⚠️ **Warning** — partially met or could be improved (explain what's missing)
-- ❌ **Missing** — requirement not met (include actionable fix suggestion)
-- ➖ **N/A** — not applicable to this project type (state why)
+- ✅ **Pass** — requirement met. Severity: omit.
+- ⚠️ **Warning** — partially met or could be improved. Severity: required (Critical/High/Medium/Low).
+- ❌ **Missing** — requirement not met. Severity: required (Critical/High/Medium/Low).
+- ➖ **N/A** — not applicable to this project type. Severity: omit.
+
+Each ⚠️ Warning and ❌ Missing finding gets a **severity level** (do NOT add severity to ✅ Pass or ➖ N/A findings):
+
+- **Critical** — immediate risk of data loss, major outage, or build/deploy break
+- **High** — significant gap that should be fixed urgently (blocks adoption, breaks a key workflow, or hides bugs)
+- **Medium** — notable gap that increases risk but doesn't pose immediate danger
+- **Low** — minor improvement or polish
+
+Format each finding using this line shape:
+
+```
+- {status} [{severity}] **{check id or short label}** {finding title} — {evidence}
+```
+
+Example: `- ❌ [High] **TS-Strict** TypeScript strict mode disabled — tsconfig.json:6 has "strict": false`
+For ✅ Pass and ➖ N/A findings, omit the `[{severity}]` slot: `- ✅ **TS-Strict** strict mode enabled — tsconfig.json:6`
 
 #### Documentation
 

--- a/.cursor/commands/melt-ux-audit.md
+++ b/.cursor/commands/melt-ux-audit.md
@@ -23,6 +23,33 @@ Before starting, determine which mode to operate in:
 2. **If a plan exists** → **Feature mode**: scope the audit to the views created or modified by this feature. Results get appended to the plan file as a `## UX Review` section.
 3. **If no plan exists** → **Full audit mode**: audit the entire application. Results produce a standalone report file (same pattern as `/melt-audit`).
 
+## Status and Severity Vocabulary
+
+Every finding has two orthogonal axes — what the check evaluated to (status) and how bad it is if it failed (severity). These vocabularies are enforced by the dashboard's database; off-vocab values are rejected on submission.
+
+Status (always set):
+
+- ✅ **Pass** — requirement met. Severity: omit.
+- ⚠️ **Warning** — partially met or could be improved. Severity: required (Critical/High/Medium/Low).
+- ❌ **Missing** — requirement not met. Severity: required (Critical/High/Medium/Low).
+- ➖ **N/A** — not applicable. Severity: omit.
+
+Severity (required on every Warning and Missing):
+
+- **Critical** — blocks core flows, makes the product unusable, or hides data the user needs to act on
+- **High** — significant usability gap that frustrates users or hides important affordances
+- **Medium** — notable polish gap that increases friction but doesn't block the flow
+- **Low** — small inconsistency or aesthetic improvement
+
+Format each finding using this line shape:
+
+```
+- {status} [{severity}] **{check label}** {finding title} — {evidence}
+```
+
+Example: `- ❌ [High] **list.back-button** No back button on detail view — clicking browser back resets list to page 1`
+For ✅ Pass and ➖ N/A findings, omit the `[{severity}]` slot.
+
 ---
 
 ## Feature Mode (Active Plan)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Package scripts are defined in `package.json`. The repo declares **pnpm** in `en
 - Local database: `docker compose up -d` (see README)
 - Run Payload migrations: `pnpm db:migrate` (alias for `payload migrate`)
 - Create a new migration: `pnpm db:create`
+- Generate Payload DB schema artifact: `pnpm db:generate` (`payload generate:db-schema`)
+- Ad hoc Payload CLI: `pnpm payload` (passes through to `payload` with `NODE_OPTIONS=--no-deprecation`)
 - Regenerate Payload TypeScript types: `pnpm generate:types`
 - Regenerate Payload admin import map: `pnpm generate:importmap`
 
@@ -73,7 +75,7 @@ For new frontend code, prefer domain-driven architecture:
 
 #### Testing (React)
 
-- Test files live in `__tests__/` within each domain, mirroring the source structure (e.g., `domains/users/__tests__/hooks/useUsersApi.test.ts`)
+- Test files live in `__tests__/` within each feature, mirroring the source structure (e.g., `src/features/users/__tests__/hooks/useUsersApi.test.ts`)
 
 ### Appendix: Next.js Standards
 
@@ -149,7 +151,7 @@ Also avoid these common agent pitfalls:
 
 For any non-trivial change (multi-file or unfamiliar code):
 
-0. Understand the story — read the full ticket/story and linked PRD before starting. If requirements are unclear, the developer should clarify with the PM or client first.
+0. Understand the story — read the full ticket/story and linked PRD before starting. If requirements are unclear, the developer should clarify with the PM or client first. When a ticket ID is known, check `.plans/` for an existing plan before writing a new one.
 
 1. Plan — explore the codebase, design the approach, define a validation plan, create the working branch, write the plan to `.plans/<sprint>/TICKET-XXX.md`
 2. Implement in small steps, validating continuously as you go
@@ -208,3 +210,5 @@ The following workflows are available as AI skills. When a developer asks you to
 - **Environment boundary (Zod)**: follow `src/config/env.ts`.
 - **App Router shell**: follow `src/app/layout.tsx` and route-group layouts under `src/app/(dashboard)/`, `(auth)/`, `(payload)/`.
 - **Tenant-style collection config**: follow `src/features/tenants/plugins/collections/index.ts` for Payload field and access patterns.
+- **TanStack Table wiring in a feature**: follow `src/features/users/hooks/useUserTable.tsx` (columns, sorting, URL/search-param patterns as used in this app).
+- **Hook-form field primitives**: follow `src/shared/components/form-hook-helper/` for controlled fields paired with `react-hook-form` + Zod.

--- a/src/features/flags/components/view-user/index.tsx
+++ b/src/features/flags/components/view-user/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Separator } from '@/shared'
+import { Badge, Button, Card, CardContent, CardHeader, Separator } from '@/shared'
 import {
   Dialog,
   DialogContent,
@@ -138,7 +138,7 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
     <Dialog>
       <DialogTrigger asChild>
         <Button variant="outline">
-          <EyeIcon className="h-4 w-4 mr-2" />
+          <EyeIcon className="h-4 w-4 mr-2" aria-hidden="true" />
           View Account
         </Button>
       </DialogTrigger>
@@ -156,18 +156,20 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
           <div className="flex flex-wrap gap-3">
             <Badge className={getStatusColor(user.status as UserStatusEnum)}>
               {user.status === UserStatusEnum.Active && (
-                <CheckCircleIcon className="w-3 h-3 mr-1" />
+                <CheckCircleIcon className="w-3 h-3 mr-1" aria-hidden="true" />
               )}
-              {user.status === UserStatusEnum.Inactive && <XCircleIcon className="w-3 h-3 mr-1" />}
-              {user.status === UserStatusEnum.Rejected && <XCircleIcon className="w-3 h-3 mr-1" />}
+              {(user.status === UserStatusEnum.Inactive ||
+                user.status === UserStatusEnum.Rejected) && (
+                <XCircleIcon className="w-3 h-3 mr-1" aria-hidden="true" />
+              )}
               {user.status === UserStatusEnum.PendingActivation && (
-                <ClockIcon className="w-3 h-3 mr-1" />
+                <ClockIcon className="w-3 h-3 mr-1" aria-hidden="true" />
               )}
               {getStatusLabel(user.status as UserStatusEnum)}
             </Badge>
             {userRoles.map((role) => (
               <Badge key={role} className={getRoleColor(role)}>
-                <ShieldIcon className="w-3 h-3 mr-1" />
+                <ShieldIcon className="w-3 h-3 mr-1" aria-hidden="true" />
                 {getRoleLabel(role)}
                 {activeRole === role && <span className="ml-1 text-xs">(Active)</span>}
               </Badge>
@@ -177,22 +179,25 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
           <Separator />
 
           <div>
-            <h4 className="font-semibold mb-3 flex items-center gap-2">
-              <LockIcon className="h-4 w-4" />
+            <h3 className="font-semibold mb-3 flex items-center gap-2">
+              <LockIcon className="h-4 w-4" aria-hidden="true" />
               Security & Compliance
-            </h4>
+            </h3>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <h5 className="font-medium mb-1">Two-Factor Authentication</h5>
+                <h4 className="font-medium mb-1">Two-Factor Authentication</h4>
                 <div className="flex items-center gap-1">
-                  <twoFAStatus.icon className={`h-4 w-4 ${twoFAStatus.color}`} />
+                  <twoFAStatus.icon className={`h-4 w-4 ${twoFAStatus.color}`} aria-hidden="true" />
                   <span className={`text-sm ${twoFAStatus.color}`}>{twoFAStatus.label}</span>
                 </div>
               </div>
               <div>
-                <h5 className="font-medium mb-1">User Password Confirmation</h5>
+                <h4 className="font-medium mb-1">User Password Confirmation</h4>
                 <div className="flex items-center gap-1">
-                  <userPasswordStatus.icon className={`h-4 w-4 ${userPasswordStatus.color}`} />
+                  <userPasswordStatus.icon
+                    className={`h-4 w-4 ${userPasswordStatus.color}`}
+                    aria-hidden="true"
+                  />
                   <span className={`text-sm ${userPasswordStatus.color}`}>
                     {userPasswordStatus.label}
                   </span>
@@ -200,13 +205,13 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
               </div>
               {securityTasks.sharedPassword && user.roles.includes('social_media_manager') && (
                 <div>
-                  <h5 className="font-medium mb-1">Shared Password Confirmation</h5>
+                  <h4 className="font-medium mb-1">Shared Password Confirmation</h4>
                   <div className="flex items-center gap-1">
                     {(() => {
                       const status = getTaskStatus(securityTasks.sharedPassword)
                       return (
                         <>
-                          <status.icon className={`h-4 w-4 ${status.color}`} />
+                          <status.icon className={`h-4 w-4 ${status.color}`} aria-hidden="true" />
                           <span className={`text-sm ${status.color}`}>{status.label}</span>
                         </>
                       )
@@ -216,16 +221,22 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
               )}
 
               <div>
-                <h5 className="font-medium mb-1">Policy Acknowledgment</h5>
+                <h4 className="font-medium mb-1">Policy Acknowledgment</h4>
                 <div className="flex items-center gap-1">
-                  <policyStatus.icon className={`h-4 w-4 ${policyStatus.color}`} />
+                  <policyStatus.icon
+                    className={`h-4 w-4 ${policyStatus.color}`}
+                    aria-hidden="true"
+                  />
                   <span className={`text-sm ${policyStatus.color}`}>{policyStatus.label}</span>
                 </div>
               </div>
               <div>
-                <h5 className="font-medium mb-1">Roll Call Confirmation</h5>
+                <h4 className="font-medium mb-1">Roll Call Confirmation</h4>
                 <div className="flex items-center gap-1">
-                  <rollCallStatus.icon className={`h-4 w-4 ${rollCallStatus.color}`} />
+                  <rollCallStatus.icon
+                    className={`h-4 w-4 ${rollCallStatus.color}`}
+                    aria-hidden="true"
+                  />
                   <span className={`text-sm ${rollCallStatus.color}`}>{rollCallStatus.label}</span>
                 </div>
               </div>
@@ -235,19 +246,19 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
           <Separator />
 
           <div>
-            <h4 className="font-semibold mb-3 flex items-center gap-2">
-              <GraduationCapIcon className="h-4 w-4" />
+            <h3 className="font-semibold mb-3 flex items-center gap-2">
+              <GraduationCapIcon className="h-4 w-4" aria-hidden="true" />
               Training & Compliance
-            </h4>
+            </h3>
             {trainingTasks.length > 0 ? (
               <div className="grid grid-cols-2 gap-4">
                 {trainingTasks.map((task) => {
                   const status = getTaskStatus(task)
                   return (
                     <div key={task.id}>
-                      <h5 className="font-medium mb-1">{task.description || 'Training Task'}</h5>
+                      <h4 className="font-medium mb-1">{task.description || 'Training Task'}</h4>
                       <div className="flex items-center gap-1">
-                        <status.icon className={`h-4 w-4 ${status.color}`} />
+                        <status.icon className={`h-4 w-4 ${status.color}`} aria-hidden="true" />
                         <span className={`text-sm ${status.color}`}>{status.label}</span>
                       </div>
                     </div>
@@ -262,10 +273,10 @@ export function ViewUser({ user, userComplianceTasks }: ViewUserProps) {
           {user.status === UserStatusEnum.Rejected && user.reject_reason && (
             <Card className="border-red-200">
               <CardHeader>
-                <CardTitle className="text-base text-red-800 flex items-center gap-2">
-                  <XCircleIcon className="w-4 h-4" />
+                <h3 className="text-base font-semibold leading-none text-red-800 flex items-center gap-2">
+                  <XCircleIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
                   Rejection Reason
-                </CardTitle>
+                </h3>
               </CardHeader>
               <CardContent>
                 <p className="text-sm text-red-700 bg-red-50 p-3 rounded-md">

--- a/src/features/social-medias/components/actions-row-social-media/index.tsx
+++ b/src/features/social-medias/components/actions-row-social-media/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useId, useState } from 'react'
 import Link from 'next/link'
 import { EyeIcon, PencilIcon } from 'lucide-react'
 import { SocialMediaStatusEnum, useChangeStatusSocialMedia } from '@/features/social-medias'
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from '@/shared/components/ui/dialog'
 import { Textarea } from '@/shared'
+import { Label } from '@/shared/components/ui/label'
 import type { AuditLog, SocialMedia, User } from '@/types/payload-types'
 import { SocialMediaDetailsDialog } from '../social-media-details'
 import { getEffectiveRoleFromUser } from '@/shared/utils/role-hierarchy'
@@ -50,6 +51,7 @@ export const ActionsRowSocialMedia: React.FC<ActionsRowSocialMediaProps> = ({
   } = useChangeStatusSocialMedia(socialMedia)
 
   const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false)
+  const deactivationReasonId = useId()
   const effectiveRole = getEffectiveRoleFromUser(user)
   const isSuperAdmin = effectiveRole === UserRolesEnum.SuperAdmin
   const isCentralAdmin = effectiveRole === UserRolesEnum.CentralAdmin
@@ -60,6 +62,11 @@ export const ActionsRowSocialMedia: React.FC<ActionsRowSocialMediaProps> = ({
   const canEdit = isSuperAdmin || isCentralAdmin || isUnitAdmin
   const canApproveActivate = isSuperAdmin || isCentralAdmin || isUnitAdmin
   const canToggleStatus = isSuperAdmin
+
+  const accountLabel =
+    stateSocialMedia.name?.trim() || `Social media account ${stateSocialMedia.id}`
+  const isAccountActive = stateSocialMedia.status === SocialMediaStatusEnum.Active
+  const statusToggleLabel = `${accountLabel}: ${isAccountActive ? 'Active' : 'Inactive'}. Toggle to change account status.`
 
   const renderActionButtons = () => {
     if (!canApproveActivate) return null
@@ -91,6 +98,7 @@ export const ActionsRowSocialMedia: React.FC<ActionsRowSocialMediaProps> = ({
             checked={stateSocialMedia.status === SocialMediaStatusEnum.Active}
             onCheckedChange={onChangeStatus}
             disabled={!isSuperAdmin && stateSocialMedia.status === SocialMediaStatusEnum.Inactive}
+            aria-label={statusToggleLabel}
           />
         )}
 
@@ -101,17 +109,22 @@ export const ActionsRowSocialMedia: React.FC<ActionsRowSocialMediaProps> = ({
           isOpen={isDetailsDialogOpen}
           onOpenChange={setIsDetailsDialogOpen}
           trigger={
-            <Button size="icon" aria-label="View social media details">
-              <EyeIcon className="h-4 w-4" />
+            <Button size="icon" aria-label={`View social media details — ${accountLabel}`}>
+              <EyeIcon className="h-4 w-4" aria-hidden="true" />
             </Button>
           }
         />
       )}
 
       {canEdit && (
-        <Button className="!text-white" asChild size="icon" aria-label="Edit social media">
+        <Button
+          className="!text-white"
+          asChild
+          size="icon"
+          aria-label={`Edit social media — ${accountLabel}`}
+        >
           <Link href={`/dashboard/social-media-accounts/update/${socialMedia.id}`}>
-            <PencilIcon className="h-4 w-4" />
+            <PencilIcon className="h-4 w-4" aria-hidden="true" />
           </Link>
         </Button>
       )}
@@ -128,11 +141,15 @@ export const ActionsRowSocialMedia: React.FC<ActionsRowSocialMediaProps> = ({
               If you deactivate this social media account, only the super admin can reactivate it,
               please provide a reason for deactivation
             </DialogDescription>
-            <Textarea
-              value={deactivationReason}
-              onChange={handleReasonChange}
-              placeholder="Please provide a reason..."
-            />
+            <div className="grid gap-2">
+              <Label htmlFor={deactivationReasonId}>Reason for deactivation</Label>
+              <Textarea
+                id={deactivationReasonId}
+                value={deactivationReason}
+                onChange={handleReasonChange}
+                placeholder="Please provide a reason..."
+              />
+            </div>
 
             <DialogFooter>
               <Button variant="secondary" onClick={handleDeactivateCancel}>

--- a/src/features/social-medias/components/social-media-details/index.tsx
+++ b/src/features/social-medias/components/social-media-details/index.tsx
@@ -72,7 +72,9 @@ export const SocialMediaDetailsDialog: React.FC<SocialMediaDetailsDialogProps> =
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {socialMedia.name || 'UNC College of Humanities'}
-            <CircleCheck />
+            {status === SocialMediaStatusEnum.Active && (
+              <CircleCheck className="h-4 w-4 text-green-600 shrink-0" aria-hidden="true" />
+            )}
           </DialogTitle>
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Badge variant="outline">{platformLabelMap[platform]}</Badge>

--- a/src/features/users/components/details/index.tsx
+++ b/src/features/users/components/details/index.tsx
@@ -82,10 +82,7 @@ export const UserDetailsDialog: React.FC<UserDetailsDialogProps> = ({
         </DialogHeader>
 
         <div className="space-y-6">
-          <InfoCard
-            icon={<UserIcon className="h-4 w-4 text-black" aria-hidden="true" />}
-            title="Basic Information"
-          >
+          <InfoCard icon={<UserIcon className="h-4 w-4 text-black" />} title="Basic Information">
             <div className="grid grid-cols-2 gap-6">
               <div className="space-y-4">
                 <InfoField label="Full Name" value={user.name} />
@@ -114,10 +111,7 @@ export const UserDetailsDialog: React.FC<UserDetailsDialogProps> = ({
             </div>
           </InfoCard>
 
-          <InfoCard
-            icon={<Key className="h-4 w-4 text-black" aria-hidden="true" />}
-            title="Security & Authentication"
-          >
+          <InfoCard icon={<Key className="h-4 w-4 text-black" />} title="Security & Authentication">
             <div className="grid grid-cols-2 gap-6">
               <div className="space-y-4">
                 <InfoField
@@ -149,7 +143,7 @@ export const UserDetailsDialog: React.FC<UserDetailsDialogProps> = ({
           </InfoCard>
 
           <InfoCard
-            icon={<GraduationCap className="h-4 w-4 text-black" aria-hidden="true" />}
+            icon={<GraduationCap className="h-4 w-4 text-black" />}
             title="Training & Compliance"
           >
             {trainingTasks.length > 0 ? (
@@ -169,7 +163,7 @@ export const UserDetailsDialog: React.FC<UserDetailsDialogProps> = ({
 
           {user.reject_reason && (
             <InfoCard
-              icon={<AlertTriangle className="h-4 w-4 text-red-600" aria-hidden="true" />}
+              icon={<AlertTriangle className="h-4 w-4 text-red-600" />}
               title="Rejection Information"
             >
               <InfoField

--- a/src/shared/components/ui/info-card.tsx
+++ b/src/shared/components/ui/info-card.tsx
@@ -19,8 +19,8 @@ export const InfoCard: React.FC<InfoCardProps> = ({
     <div className={`bg-white p-4 rounded-lg shadow-sm border ${className}`}>
       <div className="flex justify-between">
         <div className="flex items-center gap-2 mb-3">
-          {icon}
-          <h4 className="font-bold text-black">{title}</h4>
+          {icon ? <span aria-hidden="true">{icon}</span> : null}
+          <h3 className="font-bold text-black">{title}</h3>
         </div>
         {action && <div className="flex justify-end items-center">{action}</div>}
       </div>


### PR DESCRIPTION
<details>
  <summary><h2>PR Checklist</h2></summary>

- [ ] I ran the code that changed and verified that everything is working as
      expected.
- [ ] I checked the CI/CD workflows and everything is passing without errors.
- [ ] This PR is up to date with the base branch and ready to be merged.
- [ ] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [ ] I added a meaningful description for this PR.
- [ ] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR.
- [ ] I updated the README to reflect the new changes that affect the
      information in there.
- [ ] I updated all the existing unit tests to cover the changes in this PR.
- [ ] I added all the relevant screenshots (only needed for PRs that change the
      UI).
- [ ] I added the links with relevant information needed to review the PR.
- [ ] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes

- **Linear [GIQ-63](https://linear.app/meltstudio/issue/GIQ-63) (ACC-14):** WCAG 2.1 AA–oriented updates for user/social surfaces.
- **`InfoCard`:** Section titles use **`h3`** (under dialog **`h2`**); optional icons wrapped in **`aria-hidden`** to avoid duplicate announcements.
- **`UserDetailsDialog`:** Icons passed into **`InfoCard`** no longer set redundant **`aria-hidden`** on the SVG; **`CircleCheck`** in the title stays **`aria-hidden`** where it is decorative.
- **Flags `ViewUser`:** Heading outline **`h3`** / **`h4`**; decorative Lucide icons **`aria-hidden`**; rejection block uses a real **`h3`** instead of **`CardTitle`**.
- **`ActionsRowSocialMedia`:** Radix **`Switch`** has an **`aria-label`** with account context and active/inactive state; deactivation **`Textarea`** has a visible **`Label`** and **`useId`**:generated **`id`**; icon-only control labels include the account label.
- **`SocialMediaDetailsDialog`:** **`CircleCheck`** only when status is **active**, with **`aria-hidden`**.

**Process note:** There is no `.plans/giq-63.md` in-repo yet; team validation/review from `/melt-validate` and `/melt-review` was not recorded in a plan file before opening this PR.

## PR requirements (migrations, environment variables, external configs, etc.)

None.

## Screenshots

N/A — accessibility and semantics; spot-check in browser + screen reader recommended.

## Related links

- [GIQ-63 — ACC-14](https://linear.app/meltstudio/issue/GIQ-63)
