### PR TITLE
feat(web): add expandLabelContext prop to UnitCell for improved acces…

### DIFF
--- a/src/features/units/components/unit-cell/index.tsx
+++ b/src/features/units/components/unit-cell/index.tsx
@@ -3,7 +3,13 @@ import { Badge } from '@/shared'
 import { Button } from '@/shared/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/components/ui/popover'
 
-export function UnitCell({ organizations }: { organizations: Organization[] }) {
+export function UnitCell({
+  organizations,
+  expandLabelContext,
+}: {
+  organizations: Organization[]
+  expandLabelContext?: string
+}) {
   const maxVisible = 1
   const filterOrgs = organizations.filter((org) => org.name)
   const visibleOrgs = filterOrgs.slice(0, maxVisible)
@@ -23,6 +29,9 @@ export function UnitCell({ organizations }: { organizations: Organization[] }) {
 
   const expandLabel =
     remainingCount === 1 ? 'Show 1 more unit' : `Show ${remainingCount} more units`
+  const expandAriaLabel = expandLabelContext
+    ? `${expandLabel} for ${expandLabelContext}`
+    : expandLabel
 
   return (
     <div className="flex flex-wrap items-center gap-1">
@@ -38,7 +47,7 @@ export function UnitCell({ organizations }: { organizations: Organization[] }) {
             variant="outline"
             size="sm"
             className="h-auto min-h-0 shrink-0 px-2 py-0.5 text-xs font-medium"
-            aria-label={expandLabel}
+            aria-label={expandAriaLabel}
           >
             +{remainingCount} more
           </Button>

--- a/src/features/users/hooks/useUserTable.tsx
+++ b/src/features/users/hooks/useUserTable.tsx
@@ -139,8 +139,11 @@ function useUserTable({
             </Badge>
           )
         }
+        const expandLabelContext =
+          (row.getValue('name') ?? row.original.email)?.toString().trim() || undefined
+
         return organizations && organizations?.length > 0 ? (
-          <UnitCell organizations={organizations} />
+          <UnitCell organizations={organizations} expandLabelContext={expandLabelContext} />
         ) : (
           <span> - </span>
         )


### PR DESCRIPTION
feat(web): add expandLabelContext prop to UnitCell for improved accessibility

<details>
  <summary><h2>PR Checklist</h2></summary>

- [x] I ran the code that changed and verified that everything is working as
      expected.
- [x] I checked the CI/CD workflows and everything is passing without errors.
- [x] This PR is up to date with the base branch and ready to be merged.
- [x] I checked the PR changes and I'm sure that this PR only includes the
      needed changes.
- [x] I added a meaningful description for this PR.
- [ ] I added all the requirements (migrations, env variables, external
      configurations, etc.) for this PR.
- [ ] I updated the README to reflect the new changes that affect the
      information in there.
- [ ] I updated all the existing unit tests to cover the changes in this PR.
- [ ] I added all the relevant screenshots (only needed for PRs that change the
      UI).
- [x] I added the links with relevant information needed to review the PR.
- [x] :warning: I know that I own this PR until it's merged and if it remains
      open for a while, I should communicate this to my team or PM and keep it
      up to date with the base branch.

</details>

## Describe your changes

Adds an `expandLabelContext` prop to the `UnitCell` component so that the "+N more" popover trigger button has a meaningful `aria-label` containing the user's name or email. Without this context, screen readers only announce a generic label (e.g. "Show 2 more units") without identifying which user the units belong to.

**Changes:**
- `src/features/units/components/unit-cell/index.tsx` — accepts optional `expandLabelContext?: string` prop and uses it to build a descriptive `aria-label` (e.g. `"Show 2 more units for Jane Doe"`).
- `src/features/users/hooks/useUserTable.tsx` — derives `expandLabelContext` from the row's display name or email and passes it to `UnitCell`.

## PR requirements (migrations, environment variables, external configs, etc.)

None — UI-only change, no schema or environment changes required.

## Screenshots

No visual change — the "+N more" button appearance is unchanged; only its `aria-label` attribute is updated.

## Related links

- Ticket: [ACC-27 / GIQ-76](https://linear.app)